### PR TITLE
Actually emit the non-CSR warning in safe_sparse_delete_row

### DIFF
--- a/ikpykit/cluster/_utils.py
+++ b/ikpykit/cluster/_utils.py
@@ -8,6 +8,8 @@ You should have received a copy of the license along with this
 work. If not, see <https://creativecommons.org/licenses/by-nc-nd/4.0/>.
 """
 
+import warnings
+
 import numpy as np
 import scipy
 from scipy import sparse
@@ -32,7 +34,11 @@ def delete_row_csr(mat, i):
 def safe_sparse_delete_row(mat, i):
     if sparse.issparse(mat):
         if mat.format != "csr":
-            Warning("works only for CSR format -- use .tocsr()")
+            warnings.warn(
+                f"Converting {mat.format} matrix to CSR; pass a CSR matrix to "
+                "avoid the copy.",
+                stacklevel=2,
+            )
             mat = mat.tocsr()
         if isinstance(i, (list, np.ndarray)):
             for j in i:


### PR DESCRIPTION
[`ikpykit/cluster/_utils.py:35`](https://github.com/IsolationKernel/ikpykit/blob/main/ikpykit/cluster/_utils.py#L35) constructed a `Warning` and threw it away:

```python
if mat.format != "csr":
    Warning("works only for CSR format -- use .tocsr()")  # constructed, discarded
    mat = mat.tocsr()
```

`Warning(...)` is just an instantiation. Without `raise` or `warnings.warn`, nothing is emitted — callers passing a non-CSR matrix got the silent conversion with none of the notice the code meant to give.

Replaced with `warnings.warn`, and reworded to describe what actually happens. The original message ("works only for CSR format -- use .tocsr()") reads like a rejection, but the function converts and continues, so the new text says so and explains why a caller might care (the copy).

```python
if mat.format != "csr":
    warnings.warn(
        f"Converting {mat.format} matrix to CSR; pass a CSR matrix to "
        "avoid the copy.",
        stacklevel=2,
    )
    mat = mat.tocsr()
```

Verified the warning now fires and the result is unchanged:

```
warning count: 1
message: Converting csc matrix to CSR; pass a CSR matrix to avoid the copy.
result shape: (3, 3)
contents correct: True
```

Found by ruff 0.16's PLW0133, which is not enabled on the current configuration — see #56.

## Worth knowing

Neither `safe_sparse_delete_row` nor `delete_row_csr` is referenced anywhere in the project. `_utils.py` is a private module and exports nothing through `ikpykit/cluster/__init__.py`, so both functions are dead code and nothing observable changes today.

That is arguably the larger finding. Deleting the module is a reasonable follow-up, but it is a separate decision from fixing the defect, so this PR only does the latter.