### PR TITLE
Serialize docs deploys to stop concurrent pushes racing

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -18,6 +18,12 @@ jobs:
     needs: docs-check
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    # `mike deploy --push` writes to the docs_dev branch, so two deploys racing
+    # each other make the later one fail to lock the ref. Serialize them.
+    # Scoped to this job so pull request docs-check runs stay parallel.
+    concurrency:
+      group: deploy-gh-pages
+      cancel-in-progress: false
     permissions:
       contents: write
 


### PR DESCRIPTION
Fixes the `Documentation / deploy-gh-pages` failure on `05fd190`.

## What happened

`mike deploy --push` writes to the `docs_dev` branch (`remote_branch` in `mkdocs.yml`), and the job had no concurrency group. #56 and #57 merged about a minute apart, so two deploys ran at once and the second lost the race:

```
! [remote rejected] docs_dev -> docs_dev (cannot lock ref 'refs/heads/docs_dev':
  is at a28236d0c4ae34063c7f56ae36556e2feb2f11f8
  but expected 17d376ef2bb7f0de194bf5d0acda2c2c454404c2)
```

The docs built fine in both runs — `Documentation built in 14.47 seconds` — only the push failed. The red X said nothing about the commit that triggered it, which is the misleading part.

The subsequent deploy on `bfb1163` succeeded, so the published docs are current. This fixes the recurrence, not a broken deployment.

## The fix

A `concurrency` group on the deploy job:

```yaml
concurrency:
  group: deploy-gh-pages
  cancel-in-progress: false
```

On the job rather than the workflow, so pull request `docs-check` runs stay parallel — only the step that actually pushes queues up. `cancel-in-progress: false` because a cancelled deploy is a skipped publish, not a redundant one.

## Known limitation

GitHub keeps only one pending run per concurrency group, so a third deploy arriving while one is queued displaces the waiting one. For the `dev` alias that is harmless — the newer main supersedes it anyway. For version tags it would skip a publish, but tag pushes are not densely spaced enough for that to matter in practice. Worth remembering if release cadence ever changes.