### PR TITLE
Use uv sync --locked instead of --frozen in CI

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -43,7 +43,7 @@ jobs:
         enable-cache: true
 
     - name: Install docs dependencies
-      run: uv sync --frozen --no-default-groups --group docs
+      run: uv sync --locked --no-default-groups --group docs
 
     - name: Deploy docs as dev
       if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
           enable-cache: true
 
       - name: Install docs dependencies
-        run: uv sync --frozen --no-default-groups --group docs
+        run: uv sync --locked --no-default-groups --group docs
 
       - name: Build documentation (strict, execute notebooks)
         run: uv run mkdocs build --strict

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           enable-cache: true
 
       - name: Install lint dependencies
-        run: uv sync --frozen --no-default-groups --group lint
+        run: uv sync --locked --no-default-groups --group lint
 
       - name: Check format with Black
         run: uv run black --check --diff .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --frozen --no-default-groups --group dev
+          uv sync --locked --no-default-groups --group dev
 
       - name: Run tests
         run: uv run pytest --cov=ikpykit --cov-report=xml


### PR DESCRIPTION
A one-word change per workflow that closes a real gap.

Both flags install exactly what `uv.lock` says, and neither modifies it. The difference:

- `--frozen` — sync without updating the lock, **skipping any consistency check**
- `--locked` — assert the lock is consistent with `pyproject.toml`, then sync

So `--frozen` will happily install a lock that no longer matches the declared dependencies.

## This is reachable today

Editing a dependency in `pyproject.toml` without running `uv lock` leaves CI installing the stale lock and passing green, with the declared and installed dependency sets silently disagreeing. There is no separate `uv lock --check` step in any workflow to catch it either.

Confirmed by adding an unlocked dependency to `pyproject.toml`:

```
uv sync --frozen : passes  ← the gap
uv sync --locked : fails   ← correct
```

## What does not change

Resolution stays pinned to the lockfile, so CI failures remain attributable to the change under test rather than to whatever upstream published overnight. That determinism is the reason to keep a lockfile in CI at all, and this preserves it.

Applied to all four workflows that sync: `pytest.yml`, `lint.yml`, `docs.yml`, `deploy-gh-pages.yml`.

Testing against fresh resolutions — what users actually get, rather than what the dev lockfile pins — is worth doing too, but belongs in a separate scheduled job rather than in the per-PR matrix, so that an upstream break cannot block merges. That is a follow-up.