### PR TITLE
Test against fresh resolutions, and fix the lower bounds they expose

### DIFF
--- a/.github/workflows/fresh-resolution.yml
+++ b/.github/workflows/fresh-resolution.yml
@@ -1,0 +1,58 @@
+name: Fresh Resolution
+
+# The other workflows install from uv.lock, which pins a dev environment that
+# nobody who installs this package ever receives. This one ignores the lock and
+# resolves from the bounds declared in pyproject.toml, the way a user's install
+# does.
+#
+# It runs on a schedule rather than per pull request: a failure here usually
+# means an upstream release broke something, which should not block merging an
+# unrelated change.
+
+on:
+  schedule:
+    - cron: '0 3 * * 1' # Monday at 03:00
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: ${{ matrix.resolution }} on ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # highest catches upstream releases that break us.
+        # lowest-direct checks that the lower bounds in pyproject.toml are
+        # honest -- that the oldest versions we claim to support actually work.
+        resolution: [highest, lowest-direct]
+        # The ends of the supported range are where resolution differs; the
+        # versions in between add little.
+        python-version: ["3.11", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install without the lockfile
+        run: |
+          uv venv --python ${{ matrix.python-version }}
+          uv pip install --resolution ${{ matrix.resolution }} \
+            . pytest pytest-asyncio pytest-timeout
+
+      - name: Show what resolved
+        run: uv pip list
+
+      - name: Run tests
+        run: .venv/bin/pytest ikpykit -q

--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -10,6 +10,7 @@ All significant changes to this project are documented in this release file.
 | <span class="badge text-bg-danger">Fix</span>              | Bug fix                               |
 
 ## Unreleased
+- <span class="badge text-bg-api-change">API Change</span> Minimum versions of `numba`, `numpy`, and `scikit-learn` were raised to 0.63.0, 2.3.2, and 1.7.2. The previous bounds claimed support for versions that publish no wheels for Python 3.13 or 3.14, so the declared floor could not actually be installed across the supported Python range. A scheduled CI job now resolves against these bounds to keep them honest.
 - <span class="badge text-bg-feature">Feature</span> Python 3.14 is now supported and covered by CI on Linux, macOS, and Windows. Installs on 3.14 already worked, since the runtime requirements are lower bounds, but the version was neither tested nor declared.
 - <span class="badge text-bg-api-change">API Change</span> The minimum supported Python version is now 3.11 (previously 3.9). Python 3.9 reached end of life in October 2025, and NumPy and scikit-learn have already dropped support for it under SPEC 0 — installs on 3.9 and 3.10 silently resolved to noticeably older versions of the scientific stack.
 - <span class="badge text-bg-enhancement">Enhancement</span> Type annotations were modernized to PEP 604 syntax (`X | Y`, `X | None`) now that the minimum version allows it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ keywords = [
     "isolation kernel",
 ]
 dependencies = [
-    "numba>=0.60.0",
-    "numpy>=2.0.2",
+    "numba>=0.63.0",
+    "numpy>=2.3.2",
     "pandas>=2.3.3",
-    "scikit-learn>=1.6.1",
+    "scikit-learn>=1.7.2",
     "tqdm>=4.67.1",
 ]
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -829,10 +829,10 @@ lint = [
 
 [package.metadata]
 requires-dist = [
-    { name = "numba", specifier = ">=0.60.0" },
-    { name = "numpy", specifier = ">=2.0.2" },
+    { name = "numba", specifier = ">=0.63.0" },
+    { name = "numpy", specifier = ">=2.3.2" },
     { name = "pandas", specifier = ">=2.3.3" },
-    { name = "scikit-learn", specifier = ">=1.6.1" },
+    { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "tqdm", specifier = ">=4.67.1" },
 ]
 


### PR DESCRIPTION
Follow-up to #62.

## Why

Every existing workflow installs from `uv.lock`, which pins a dev environment that nobody who installs this package receives. `[project].dependencies` are lower bounds, so what users actually get is a fresh resolution — and nothing tested it.

The Python 3.14 work (#61) showed what that costs. The lock said 3.14 was unsupported because it pinned numba 0.62.1, which has no cp314 wheels. A real install resolved numba 0.67.0 and worked fine. The lockfile gave a false negative about the thing users care about.

## The new workflow

`.github/workflows/fresh-resolution.yml` ignores the lock and resolves from the declared bounds, at both ends of the supported Python range:

| resolution | what it catches |
|---|---|
| `highest` | upstream releases that break us |
| `lowest-direct` | a declared floor that isn't actually installable |

Weekly on a schedule plus `workflow_dispatch`, deliberately **not** per pull request — a failure here usually means upstream published something, and that should not block merging an unrelated change.

## What lowest-direct found immediately

The bounds as they stood were wrong:

| package | old bound | wheels published through |
|---|---|---|
| `numba>=0.60.0` | 0.60.0 | **cp312** |
| `numpy>=2.0.2` | 2.0.2 | **cp312** |
| llvmlite (transitive) | 0.43.0 | **cp312** |

On Python 3.13 and 3.14 the declared floor could not be installed at all. The metadata claimed combinations that do not exist. Nobody noticed because resolvers pick the highest compatible version, so real users never touch the floor — but anyone using a constraints file, an older resolver, or a downstream solver pinning low would hit it.

Raised to the earliest releases carrying cp314 wheels:

- `numba>=0.63.0`
- `numpy>=2.3.2`
- `scikit-learn>=1.7.2`

`pandas>=2.3.3` and `tqdm>=4.67.1` were already correct.

Verified `lowest-direct` now resolves to wheel-backed versions on both ends:

```
Python 3.11: numba 0.63.0, numpy 2.3.2, scipy 1.17.1, pandas 2.3.3, scikit-learn 1.7.2
Python 3.14: numba 0.63.0, numpy 2.3.2, scipy 1.18.0, pandas 2.3.3, scikit-learn 1.7.2
```

`uv.lock` is regenerated for the new constraints; no locked version actually changes, only the constraint metadata.

## Trade-off worth naming

Raising the floor globally means a user on 3.11 can no longer pair this with numpy 2.0.2. Per-version markers would be more precise, but they would also assert combinations nobody tests. A single honest floor that CI verifies seems better than a looser one that is decorative. If the 3.11-with-old-numpy case ever matters, markers are the way to reintroduce it.

## Note

The scheduled job's failures surface in the Actions tab only. If this should open an issue or notify somewhere on failure, that is worth adding — I left it out rather than guess at where notifications should go.