### PR TITLE
Add a CI gate job and stop building the docs twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,21 @@ jobs:
 
   docs:
     uses: ./.github/workflows/docs.yml
+
+  # Single check for branch protection to require. Naming the individual jobs
+  # there would not survive a matrix change: a newly added Python version would
+  # not be required, and a removed one would leave a required check that never
+  # reports, blocking every pull request.
+  ci-passed:
+    name: CI passed
+    needs: [lint, tests, docs]
+    # Runs even when something upstream fails, so the result is a real failure
+    # rather than a skip. A skipped required check does not block a merge.
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any job did not succeed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: |
+          echo "lint=${{ needs.lint.result }} tests=${{ needs.tests.result }} docs=${{ needs.docs.result }}"
+          exit 1

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -11,7 +11,10 @@ on:
       - main
 
 jobs:
+  # Gates the deploy below. On pull requests ci.yml already runs the same
+  # reusable workflow, so running it here too built the docs twice per event.
   docs-check:
+    if: ${{ github.event_name == 'push' }}
     uses: ./.github/workflows/docs.yml
 
   deploy-gh-pages:


### PR DESCRIPTION
Groundwork for enabling branch protection on `main`.

## Why a gate job

Branch protection needs status checks to require. Naming them individually would mean listing 15 contexts, 12 of which are matrix entries:

```
tests / test (ubuntu-latest, 3.11)
tests / test (ubuntu-latest, 3.12)
... 10 more
lint / lint
docs / docs
```

That does not survive a matrix change in either direction. Adding Python 3.15 would leave the new job unrequired, and dropping 3.11 would leave a required check that never reports — which blocks every pull request until someone edits the protection settings.

`ci-passed` depends on `lint`, `tests`, and `docs`, so it stays correct as those evolve. Branch protection requires one name.

### The `if: always()` detail

```yaml
if: always()
steps:
  - if: contains(needs.*.result, 'failure') || ...
    run: exit 1
```

Without `always()`, a failure upstream *skips* the gate instead of failing it — and GitHub does not treat a skipped required check as blocking. The job has to run and fail explicitly.

## The duplicate docs build

Unrelated to protection, but visible in the same check list. The docs were built twice on every event:

```yaml
# ci.yml
docs:
  uses: ./.github/workflows/docs.yml

# deploy-gh-pages.yml
docs-check:
  uses: ./.github/workflows/docs.yml   # same workflow, again
```

That is why every PR showed both `docs / docs` and `docs-check / docs` passing. `docs-check` exists only to gate the deploy step, which is already push-only, so it now carries the same condition. Pull requests go from 15 checks to 13; the deploy path on `main` is unchanged.

## Next

Once this is on `main` and `ci-passed` has reported once, protection can require it with "Require branches to be up to date before merging". That closes the gap #59 sat in — green checks against a base five commits stale, and GitHub still calling it mergeable.