### PR TITLE
Prepare the v0.3.0 changelog

### DIFF
--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -9,13 +9,17 @@ All significant changes to this project are documented in this release file.
 | <span class="badge text-bg-api-change">API Change</span>   | Changes in the API                    |
 | <span class="badge text-bg-danger">Fix</span>              | Bug fix                               |
 
-## Unreleased
-- <span class="badge text-bg-api-change">API Change</span> Minimum versions of `numba`, `numpy`, and `scikit-learn` were raised to 0.63.0, 2.3.2, and 1.7.2. The previous bounds claimed support for versions that publish no wheels for Python 3.13 or 3.14, so the declared floor could not actually be installed across the supported Python range. A scheduled CI job now resolves against these bounds to keep them honest.
+## Released (2026-08-16, v0.3.0)
+
+This release raises the minimum Python version and the minimum versions of several runtime dependencies. Both are breaking for anyone on an older environment; everything else is additive or internal.
+
 - <span class="badge text-bg-feature">Feature</span> Python 3.14 is now supported and covered by CI on Linux, macOS, and Windows. Installs on 3.14 already worked, since the runtime requirements are lower bounds, but the version was neither tested nor declared.
 - <span class="badge text-bg-api-change">API Change</span> The minimum supported Python version is now 3.11 (previously 3.9). Python 3.9 reached end of life in October 2025, and NumPy and scikit-learn have already dropped support for it under SPEC 0 — installs on 3.9 and 3.10 silently resolved to noticeably older versions of the scientific stack.
+- <span class="badge text-bg-api-change">API Change</span> Minimum versions of `numba`, `numpy`, and `scikit-learn` were raised to 0.63.0, 2.3.2, and 1.7.2. The previous bounds claimed support for versions that publish no wheels for Python 3.13 or 3.14, so the declared floor could not actually be installed across the supported Python range. A scheduled CI job now resolves against these bounds to keep them honest.
 - <span class="badge text-bg-enhancement">Enhancement</span> Type annotations were modernized to PEP 604 syntax (`X | Y`, `X | None`) now that the minimum version allows it.
 - <span class="badge text-bg-enhancement">Enhancement</span> All `zip()` calls over collections that are equal-length by construction now pass `strict=True`, so a length mismatch raises instead of silently truncating.
-- <span class="badge text-bg-danger">Fix</span> Locked development dependencies were upgraded to clear 76 security advisories. These were confined to the docs and dev dependency groups and never reached the published package, whose runtime requirements are unchanged.
+- <span class="badge text-bg-danger">Fix</span> Spelling errors were corrected in user-facing documentation, including IKTOD's class docstring and a variable name in the IKGOD usage example.
+- <span class="badge text-bg-danger">Fix</span> Locked development dependencies were upgraded, clearing all open security advisories. These were confined to the docs and dev dependency groups and never reached the published package, whose runtime requirements are unaffected.
 
 ## Released (2026-03-22, v0.2.4 Hotfix)
 - <span class="badge text-bg-danger">Fix</span> Converted hard-coded site links in the docs home page to version-safe relative links, so navigation works under `latest`, `dev`, and versioned routes.


### PR DESCRIPTION
Closes the Unreleased section and dates it 2026-08-16.

## Why v0.3.0

Two API changes, both breaking for older environments:

- minimum Python raised 3.9 → 3.11
- minimum `numba`, `numpy`, `scikit-learn` raised to 0.63.0, 2.3.2, 1.7.2

On a 0.x version, a minor bump is how that gets signalled. Last release was v0.2.4.

## Changes while closing it out

Entries are reordered so the two API changes sit together near the top — that is what anyone upgrading needs to read first.

Two corrections:

- The security entry claimed "76 security advisories". That was a mid-work count taken from analysing the lockfile, not the final state. GitHub now reports every advisory resolved, so the number is dropped in favour of saying that plainly.
- A Fix entry is added for the spelling corrections in IKTOD's class docstring and the IKGOD usage example. Those are user-facing documentation and were not recorded.

Deliberately left out: the internal-only work from this batch — CI restructuring, the pre-commit repair, removal of the unused `cluster/_utils.py` and `pixi.lock`. None of it is observable to anyone installing the package.

## After this merges

Tagging `v0.3.0` triggers `pypi.yml`, which publishes to **PyPI** and creates a GitHub Release, and `deploy-gh-pages.yml`, which deploys versioned docs and moves the `latest` alias. A PyPI version number can never be reused, so that step should be taken deliberately rather than as a follow-on.

## Verification

`mkdocs build --strict` passes, so the changelog page renders. All six pre-commit hooks pass.